### PR TITLE
feat: add sample-ui to use as basis for testing

### DIFF
--- a/apps/sample-ui/package.json
+++ b/apps/sample-ui/package.json
@@ -12,7 +12,9 @@
     "@types/react-dom": "^17.0.11",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-query": "^3.34.14",
     "react-scripts": "5.0.0",
+    "recoil": "^0.6.1",
     "typescript": "^4.5.3",
     "web-vitals": "^2.1.4"
   },

--- a/apps/sample-ui/src/App.test.tsx
+++ b/apps/sample-ui/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/apps/sample-ui/src/App.tsx
+++ b/apps/sample-ui/src/App.tsx
@@ -1,26 +1,19 @@
-import React from 'react';
-import logo from './logo.svg';
-import './App.css';
+import './App.css'
+import { useRecoilValue } from 'recoil'
+import Login from './components/Login'
+import Main from './components/Main'
+import { userProfileState } from './state/userProfile'
 
 function App() {
+  const userProfile = useRecoilValue(userProfileState)
+
+  const isAuth = Object.keys(userProfile).length !== 0
+
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+      <header className="App-header">{isAuth ? <Main /> : <Login />}</header>
     </div>
-  );
+  )
 }
 
-export default App;
+export default App

--- a/apps/sample-ui/src/components/Login.tsx
+++ b/apps/sample-ui/src/components/Login.tsx
@@ -1,0 +1,50 @@
+import { FormEvent, useState } from 'react'
+import { useRecoilState } from 'recoil'
+import { IUserProfile, userProfileState } from '../state/userProfile'
+
+function mockLoginRequest(): Promise<{
+  status: string
+  user: IUserProfile
+}> {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve({
+        status: 'OK',
+        user: {
+          username: 'userA',
+          permissions: ['AMAZING_ADMIN_PERMISSION'],
+        },
+      })
+    }, 2000)
+  })
+}
+
+const Login = () => {
+  const [, setUserProfile] = useRecoilState(userProfileState)
+
+  const [isLoading, setIsLoading] = useState(false)
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    setIsLoading(true)
+
+    const res = await mockLoginRequest()
+
+    if (res.status !== 'OK') {
+      setIsLoading(false)
+      return
+    }
+
+    setUserProfile(res.user)
+  }
+  return (
+    <form onSubmit={onSubmit}>
+      <input type="text" name="username" aria-label="Username" />
+      <input type="password" name="password" aria-label="Password" />
+      {isLoading ? 'loading...' : <button type="submit">Login</button>}
+    </form>
+  )
+}
+
+export default Login

--- a/apps/sample-ui/src/components/Main.tsx
+++ b/apps/sample-ui/src/components/Main.tsx
@@ -1,0 +1,62 @@
+import { useQuery } from 'react-query'
+import { useRecoilValue } from 'recoil'
+import { userProfileState } from '../state/userProfile'
+
+/**
+ * 1) login (2 accounts)
+ * 2) after login, show a button
+ * 3) user A will get a success
+ * 4) user B will fail
+ */
+
+function getMagicItems() {
+  return fetch('http://localhost:4001/magicitems').then(res => res.json())
+}
+
+const Main = () => {
+  const userProfile = useRecoilValue(userProfileState)
+
+  const magicItemsQuery = useQuery<string[], Error>(
+    'magicItems',
+    getMagicItems,
+    {
+      enabled: false,
+    }
+  )
+
+  return (
+    <>
+      <span>heyllo, {userProfile.username}</span>
+
+      <div>
+        {magicItemsQuery.isFetching ? (
+          <span>Loading...</span>
+        ) : (
+          <button
+            onClick={() => {
+              magicItemsQuery.refetch()
+            }}
+          >
+            Get Magic Items From API!
+          </button>
+        )}
+      </div>
+
+      {magicItemsQuery.error && (
+        <span>{`An error has occurred: ${magicItemsQuery.error.message}`}</span>
+      )}
+
+      {!magicItemsQuery.isFetching && magicItemsQuery.data?.length === 0 ? (
+        <span>nothing but us chickens</span>
+      ) : (
+        <ol>
+          {magicItemsQuery.data?.map((item, index) => (
+            <li key={index}>{item}</li>
+          ))}
+        </ol>
+      )}
+    </>
+  )
+}
+
+export default Main

--- a/apps/sample-ui/src/index.tsx
+++ b/apps/sample-ui/src/index.tsx
@@ -1,17 +1,25 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
+import './index.css'
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { QueryClient, QueryClientProvider } from 'react-query'
+import { RecoilRoot } from 'recoil'
+import App from './App'
+import reportWebVitals from './reportWebVitals'
+
+const queryClient = new QueryClient()
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <RecoilRoot>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </RecoilRoot>
   </React.StrictMode>,
   document.getElementById('root')
-);
+)
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();
+reportWebVitals()

--- a/apps/sample-ui/src/reportWebVitals.ts
+++ b/apps/sample-ui/src/reportWebVitals.ts
@@ -1,15 +1,15 @@
-import { ReportHandler } from 'web-vitals';
+import { ReportHandler } from 'web-vitals'
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
     import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry);
-      getFID(onPerfEntry);
-      getFCP(onPerfEntry);
-      getLCP(onPerfEntry);
-      getTTFB(onPerfEntry);
-    });
+      getCLS(onPerfEntry)
+      getFID(onPerfEntry)
+      getFCP(onPerfEntry)
+      getLCP(onPerfEntry)
+      getTTFB(onPerfEntry)
+    })
   }
-};
+}
 
-export default reportWebVitals;
+export default reportWebVitals

--- a/apps/sample-ui/src/setupTests.ts
+++ b/apps/sample-ui/src/setupTests.ts
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom'

--- a/apps/sample-ui/src/state/userProfile.ts
+++ b/apps/sample-ui/src/state/userProfile.ts
@@ -1,0 +1,13 @@
+import { atom } from 'recoil'
+
+export interface IUserProfile {
+  username: string
+  permissions?: string[]
+}
+
+const initialUserProfileState: Partial<IUserProfile> = {}
+
+export const userProfileState = atom({
+  key: 'userProfile',
+  default: initialUserProfileState,
+})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,7 +54,9 @@ importers:
       '@types/react-dom': ^17.0.11
       react: ^17.0.2
       react-dom: ^17.0.2
+      react-query: ^3.34.14
       react-scripts: 5.0.0
+      recoil: ^0.6.1
       tsconfig: workspace:*
       typescript: ^4.5.3
       web-vitals: ^2.1.4
@@ -68,7 +70,9 @@ importers:
       '@types/react-dom': 17.0.11
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
+      react-query: 3.34.14_react-dom@17.0.2+react@17.0.2
       react-scripts: 5.0.0_react@17.0.2+typescript@4.5.5
+      recoil: 0.6.1_react-dom@17.0.2+react@17.0.2
       typescript: 4.5.5
       web-vitals: 2.1.4
     devDependencies:
@@ -4576,6 +4580,11 @@ packages:
       tryer: 1.0.1
     dev: false
 
+  /big-integer/1.6.51:
+    resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
+    engines: {node: '>=0.6'}
+    dev: false
+
   /big.js/5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
 
@@ -4638,6 +4647,19 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
+
+  /broadcast-channel/3.7.0:
+    resolution: {integrity: sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==}
+    dependencies:
+      '@babel/runtime': 7.17.0
+      detect-node: 2.1.0
+      js-sha3: 0.8.0
+      microseconds: 0.2.0
+      nano-time: 1.0.0
+      oblivious-set: 1.0.0
+      rimraf: 3.0.2
+      unload: 2.2.0
+    dev: false
 
   /browser-process-hrtime/1.0.0:
     resolution: {integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==}
@@ -6954,6 +6976,10 @@ packages:
     dependencies:
       duplexer: 0.1.2
 
+  /hamt_plus/1.0.2:
+    resolution: {integrity: sha1-4hwlKWjH4zsg9qGwlM2FeHomVgE=}
+    dev: false
+
   /handle-thing/2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
 
@@ -8184,6 +8210,10 @@ packages:
       '@sideway/formula': 3.0.0
       '@sideway/pinpoint': 2.0.0
 
+  /js-sha3/0.8.0:
+    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
+    dev: false
+
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -8539,6 +8569,13 @@ packages:
   /markdown-escapes/1.0.4:
     resolution: {integrity: sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==}
 
+  /match-sorter/6.3.1:
+    resolution: {integrity: sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==}
+    dependencies:
+      '@babel/runtime': 7.17.0
+      remove-accents: 0.4.2
+    dev: false
+
   /mdast-squeeze-paragraphs/4.0.0:
     resolution: {integrity: sha512-zxdPn69hkQ1rm4J+2Cs2j6wDEv7O17TfXTJ33tl/+JPIoEmtV9t2ZzBM5LPHE8QlHsmVD8t3vPKCyY3oH+H8MQ==}
     dependencies:
@@ -8604,6 +8641,10 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
+
+  /microseconds/0.2.0:
+    resolution: {integrity: sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==}
+    dev: false
 
   /mime-db/1.33.0:
     resolution: {integrity: sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==}
@@ -8719,6 +8760,12 @@ packages:
     dependencies:
       dns-packet: 1.3.4
       thunky: 1.1.0
+
+  /nano-time/1.0.0:
+    resolution: {integrity: sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=}
+    dependencies:
+      big-integer: 1.6.51
+    dev: false
 
   /nanoid/3.2.0:
     resolution: {integrity: sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==}
@@ -8942,6 +8989,10 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.1.3
       es-abstract: 1.19.1
+    dev: false
+
+  /oblivious-set/1.0.0:
+    resolution: {integrity: sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==}
     dev: false
 
   /obuf/1.1.2:
@@ -10325,6 +10376,25 @@ packages:
       react-loadable: /@docusaurus/react-loadable/5.5.2_react@17.0.2
       webpack: 5.68.0
 
+  /react-query/3.34.14_react-dom@17.0.2+react@17.0.2:
+    resolution: {integrity: sha512-KVMnM8omt+81oO9fPZfM65pGhQilpWzGsNwAqeeLMB2sG3xwY3bpIEYbhDf7FFgsqhAQfSzmCL4gRSiJaWIDwA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.17.0
+      broadcast-channel: 3.7.0
+      match-sorter: 6.3.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    dev: false
+
   /react-refresh/0.11.0:
     resolution: {integrity: sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==}
     engines: {node: '>=0.10.0'}
@@ -10534,6 +10604,23 @@ packages:
     dependencies:
       resolve: 1.22.0
 
+  /recoil/0.6.1_react-dom@17.0.2+react@17.0.2:
+    resolution: {integrity: sha512-J7oT3LZl2vpyFClgSUpOQjpykz84VSX/NJE/PavAtR8n7Z+whEdVBPUtwc2TEWjONeL/lJmiac2XQ+qEOQA52Q==}
+    peerDependencies:
+      react: '>=16.13.1'
+      react-dom: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+    dependencies:
+      hamt_plus: 1.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    dev: false
+
   /recursive-readdir/2.2.2:
     resolution: {integrity: sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==}
     engines: {node: '>=0.10.0'}
@@ -10714,6 +10801,10 @@ packages:
     resolution: {integrity: sha512-8qRqmL9F4nuLPIgl92XUuxI3pFxize+F1H0e/W3llTk0UsjJaj01+RrirkMw7P21RKe4X6goQhYRSvNWX+70Rw==}
     dependencies:
       mdast-squeeze-paragraphs: 4.0.0
+
+  /remove-accents/0.4.2:
+    resolution: {integrity: sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=}
+    dev: false
 
   /renderkid/3.0.0:
     resolution: {integrity: sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==}
@@ -12088,6 +12179,13 @@ packages:
   /universalify/2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
+
+  /unload/2.2.0:
+    resolution: {integrity: sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==}
+    dependencies:
+      '@babel/runtime': 7.17.0
+      detect-node: 2.1.0
+    dev: false
 
   /unpipe/1.0.0:
     resolution: {integrity: sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=}


### PR DESCRIPTION
I'm thinking about building the first scenario where:
* there are 2 users, User A and User B
* one of them have permission to do action C because they have permission D
* so there should be 2 test runs, and for each test run, a mock of the response will be stored separately

---

From this scenario, there should already be quite a few prerequisite that we don't have yet:
1. #5
2. #6
3. #7
4. #8